### PR TITLE
add priority-batched restart mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an [Ansible](https://www.ansible.com/) role which manages systemd servic
 
 ## Features
 
-- **starting** (restarting) services, in order, according to their `priority`. Services can all be stopped cleanly and then started anew, or they can be restarted one-by-one (see `devture_systemd_service_manager_service_restart_mode`)
+- **starting** (restarting) services, in order, according to their `priority`. Services can all be stopped cleanly and then started anew, restarted one-by-one, or started in priority batches without blocking (see `devture_systemd_service_manager_service_restart_mode`)
 
 - making services **auto-start** (see `devture_systemd_service_manager_services_autostart_enabled`)
 
@@ -15,7 +15,7 @@ This is an [Ansible](https://www.ansible.com/) role which manages systemd servic
 
 - starting/stopping all defined services, or a group of services (`--tags=restart-group`, `--tags=stop-group`)
 
-- restarting services by cleanly stopping them and restarting them, or one by one
+- restarting services by cleanly stopping them and restarting them, one by one, or by priority batches
 
 
 ## Usage
@@ -51,3 +51,8 @@ Example playbook invocations tags (e.g. `ansible-playbook -i inventory/hosts set
 
 - `stop-group` - stops services belonging to the specified group (e.g. `--extra-vars="group=core"`)
 
+Restart mode options for `devture_systemd_service_manager_service_restart_mode`:
+
+- `clean-stop-start` (default) - stops all services in reverse priority order, then starts them in priority order
+- `one-by-one` - restarts each service in priority order
+- `priority-batched` - starts/restarts services in priority batches and queues them without blocking inside each batch

--- a/tasks/restart_specified.yml
+++ b/tasks/restart_specified.yml
@@ -48,6 +48,25 @@
       with_items: "{{ devture_systemd_service_manager_services_list_to_work_with | sort (attribute='priority,name') }}"
       when: not ansible_check_mode
 
+- when: devture_systemd_service_manager_service_restart_mode == 'priority-batched'
+  block:
+    - name: Collect unique priorities for batched restarts
+      ansible.builtin.set_fact:
+        devture_systemd_service_manager_priorities: >-
+          {{
+            (devture_systemd_service_manager_services_list_to_work_with | map(attribute='priority') | list)
+            | unique | sort
+          }}
+
+    - name: Restart systemd services in priority batches
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/util/start_priority_batch.yml"
+      vars:
+        devture_systemd_service_manager_services_list_to_start: "{{ devture_systemd_service_manager_services_list_to_work_with }}"
+        devture_systemd_service_manager_target_state: restarted
+      loop: "{{ devture_systemd_service_manager_priorities }}"
+      loop_control:
+        loop_var: priority
+
 - when: devture_systemd_service_manager_up_verification_enabled | bool and devture_systemd_service_manager_services_list_to_work_with | length > 0
   name: Verify that systemd services started successfully
   block:

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -31,6 +31,25 @@
       with_items: "{{ devture_systemd_service_manager_services_list | sort (attribute='priority,name') }}"
       when: not ansible_check_mode
 
+- when: devture_systemd_service_manager_service_restart_mode == 'priority-batched'
+  block:
+    - name: Collect unique priorities for batched starts
+      ansible.builtin.set_fact:
+        devture_systemd_service_manager_priorities: >-
+          {{
+            (devture_systemd_service_manager_services_list | map(attribute='priority') | list)
+            | unique | sort
+          }}
+
+    - name: Start systemd services in priority batches
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/util/start_priority_batch.yml"
+      vars:
+        devture_systemd_service_manager_services_list_to_start: "{{ devture_systemd_service_manager_services_list }}"
+        devture_systemd_service_manager_target_state: started
+      loop: "{{ devture_systemd_service_manager_priorities }}"
+      loop_control:
+        loop_var: priority
+
 - when: devture_systemd_service_manager_up_verification_enabled | bool and not ansible_check_mode
   name: Verify that systemd services started successfully
   block:

--- a/tasks/util/start_priority_batch.yml
+++ b/tasks/util/start_priority_batch.yml
@@ -1,0 +1,21 @@
+---
+- name: Collect services for priority {{ priority }}
+  ansible.builtin.set_fact:
+    devture_systemd_service_manager_priority_services: >-
+      {{
+        devture_systemd_service_manager_services_list_to_start
+        | selectattr('priority', 'equalto', priority)
+        | sort(attribute='name')
+        | list
+      }}
+
+- name: Start systemd services for priority {{ priority }} without blocking
+  ansible.builtin.systemd:
+    name: "{{ item.name }}"
+    state: "{{ devture_systemd_service_manager_target_state }}"
+    enabled: "{{ devture_systemd_service_manager_services_autostart_enabled }}"
+    no_block: true
+  loop: "{{ devture_systemd_service_manager_priority_services }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: not ansible_check_mode

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -4,4 +4,4 @@
   ansible.builtin.fail:
     msg: >-
       Invalid value: `{{ devture_systemd_service_manager_service_restart_mode }}`
-  when: "devture_systemd_service_manager_service_restart_mode not in ['clean-stop-start', 'one-by-one']"
+  when: "devture_systemd_service_manager_service_restart_mode not in ['clean-stop-start', 'one-by-one', 'priority-batched']"


### PR DESCRIPTION
This PR adds a priority-batched restart mode that queues systemd service restarts quickly while still respecting service priority order.

Testing server results:

**one-by-one**

```
real	12m50.008s
user	1m9.269s
sys	0m9.090s
```

**priority-batched**

```
real	5m38.453s
user	1m3.241s
sys	0m7.847s
```