### PR TITLE
Add bounded retry for all-at-once restart mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,9 @@ Restart mode options for `devture_systemd_service_manager_service_restart_mode`:
 - `one-by-one` - restarts each service in priority order
 - `priority-batched` - starts/restarts services in priority batches and queues them without blocking inside each batch
 
+All-at-once retry controls:
+
+- `devture_systemd_service_manager_all_at_once_retry_attempts` (default: `1`) - number of attempts for each single all-at-once `systemctl restart ...` or `systemctl start ...` command
+- `devture_systemd_service_manager_all_at_once_retry_delay_seconds` (default: `10`) - delay between attempts
+
 For a detailed comparison of these modes with real-world downtime benchmarks, see [Restart Mode Comparison](docs/restart-mode-comparison.md).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,11 +55,12 @@ devture_systemd_service_manager_services_list: "{{ devture_systemd_service_manag
 devture_systemd_service_manager_service_restart_mode: all-at-once
 
 # When `devture_systemd_service_manager_service_restart_mode` is `all-at-once`,
-# this controls how many total attempts are made for the single `systemctl restart ...` command.
+# this controls how many total attempts are made for each single all-at-once `systemctl restart ...`
+# or `systemctl start ...` command.
 # Set to 1 to preserve fail-fast behavior (1 attempt, no retries).
 devture_systemd_service_manager_all_at_once_retry_attempts: 1
 
-# Delay between retries for `all-at-once` restart attempts.
+# Delay between retries for `all-at-once` restart/start attempts.
 devture_systemd_service_manager_all_at_once_retry_delay_seconds: 10
 
 # devture_systemd_service_manager_conditional_restart_enabled controls whether

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,14 @@ devture_systemd_service_manager_services_list: "{{ devture_systemd_service_manag
 # the restart transaction internally on the server side.
 devture_systemd_service_manager_service_restart_mode: all-at-once
 
+# When `devture_systemd_service_manager_service_restart_mode` is `all-at-once`,
+# this controls how many total attempts are made for the single `systemctl restart ...` command.
+# Set to 1 to preserve fail-fast behavior (1 attempt, no retries).
+devture_systemd_service_manager_all_at_once_retry_attempts: 1
+
+# Delay between retries for `all-at-once` restart attempts.
+devture_systemd_service_manager_all_at_once_retry_delay_seconds: 10
+
 # devture_systemd_service_manager_conditional_restart_enabled controls whether
 # services can opt out of restarting when their configuration hasn't changed.
 #

--- a/tasks/restart_specified.yml
+++ b/tasks/restart_specified.yml
@@ -145,6 +145,10 @@
         - name: Restart systemd services needing restart at once
           ansible.builtin.command:
             cmd: "{{ devture_systemd_service_manager_all_at_once_restart_command }}"
+          register: devture_systemd_service_manager_all_at_once_restart_result
+          retries: "{{ [((devture_systemd_service_manager_all_at_once_retry_attempts | int) - 1), 0] | max }}"
+          delay: "{{ devture_systemd_service_manager_all_at_once_retry_delay_seconds | int }}"
+          until: devture_systemd_service_manager_all_at_once_restart_result.rc == 0
           when: not ansible_check_mode
 
     - when: not ansible_check_mode and devture_systemd_service_manager_services_actually_needing_start | default([]) | length > 0

--- a/tasks/restart_specified.yml
+++ b/tasks/restart_specified.yml
@@ -166,6 +166,10 @@
         - name: Start services that are not yet running
           ansible.builtin.command:
             cmd: "{{ devture_systemd_service_manager_all_at_once_start_command }}"
+          register: devture_systemd_service_manager_all_at_once_start_missing_result
+          retries: "{{ [((devture_systemd_service_manager_all_at_once_retry_attempts | int) - 1), 0] | max }}"
+          delay: "{{ devture_systemd_service_manager_all_at_once_retry_delay_seconds | int }}"
+          until: devture_systemd_service_manager_all_at_once_start_missing_result.rc == 0
 
     - name: Ensure systemd services are auto-started
       ansible.builtin.command:

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -65,6 +65,10 @@
     - name: Start all systemd services at once
       ansible.builtin.command:
         cmd: "{{ devture_systemd_service_manager_all_at_once_start_command }}"
+      register: devture_systemd_service_manager_all_at_once_start_result
+      retries: "{{ [((devture_systemd_service_manager_all_at_once_retry_attempts | int) - 1), 0] | max }}"
+      delay: "{{ devture_systemd_service_manager_all_at_once_retry_delay_seconds | int }}"
+      until: devture_systemd_service_manager_all_at_once_start_result.rc == 0
       when: not ansible_check_mode
 
     - name: Ensure systemd services are auto-started

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -5,3 +5,23 @@
     msg: >-
       Invalid value: `{{ devture_systemd_service_manager_service_restart_mode }}`
   when: "devture_systemd_service_manager_service_restart_mode not in ['clean-stop-start', 'one-by-one', 'priority-batched', 'all-at-once']"
+
+- name: Fail if devture_systemd_service_manager_all_at_once_retry_attempts is invalid
+  ansible.builtin.fail:
+    msg: >-
+      Invalid value for `devture_systemd_service_manager_all_at_once_retry_attempts`:
+      `{{ devture_systemd_service_manager_all_at_once_retry_attempts }}`.
+      The value must be an integer greater than or equal to 1.
+  when:
+    - devture_systemd_service_manager_service_restart_mode == 'all-at-once'
+    - "(devture_systemd_service_manager_all_at_once_retry_attempts | int) < 1"
+
+- name: Fail if devture_systemd_service_manager_all_at_once_retry_delay_seconds is invalid
+  ansible.builtin.fail:
+    msg: >-
+      Invalid value for `devture_systemd_service_manager_all_at_once_retry_delay_seconds`:
+      `{{ devture_systemd_service_manager_all_at_once_retry_delay_seconds }}`.
+      The value must be an integer greater than or equal to 0.
+  when:
+    - devture_systemd_service_manager_service_restart_mode == 'all-at-once'
+    - "(devture_systemd_service_manager_all_at_once_retry_delay_seconds | int) < 0"


### PR DESCRIPTION
## Problem
In `all-at-once` mode, bounded retry was only applied to one restart command path. Other all-at-once start paths still had single-shot behavior.

## Root Cause
Retry wiring was added only for `systemctl restart ...` in `tasks/restart_specified.yml`.

## Fix
- keep retry knobs and defaults unchanged:
  - `devture_systemd_service_manager_all_at_once_retry_attempts` (default `1`)
  - `devture_systemd_service_manager_all_at_once_retry_delay_seconds` (default `10`)
- apply retries consistently to:
  - restart path in `tasks/restart_specified.yml`
  - start-missing path in `tasks/restart_specified.yml`
  - start-all path in `tasks/start.yml`
- add validation in `tasks/validate_config.yml`:
  - attempts must be `>= 1`
  - delay must be `>= 0`
- document retry controls in `README.md` and clarify defaults comment text in `defaults/main.yml`

## Compatibility
No behavior change when using default attempts (`1`). This remains backward compatible and fail-fast by default.

## Validation
- `ansible-lint --profile=min -x role-name .` passed